### PR TITLE
Simplify salt_generate

### DIFF
--- a/src/resources/password/salt_generate.nim
+++ b/src/resources/password/salt_generate.nim
@@ -8,7 +8,7 @@ proc makeSalt*(): string =
   ## Generate random salt. Uses cryptographically secure /dev/urandom
   ## on platforms where it is available, and Nim's random module in other cases.
   result = ""
-  if not useUrandom:
+  if useUrandom:
     var randomBytes: array[0..127, char]
     discard urandom.readBuffer(addr(randomBytes), 128)
     for ch in randomBytes:

--- a/src/resources/password/salt_generate.nim
+++ b/src/resources/password/salt_generate.nim
@@ -1,49 +1,19 @@
-import math, random
-
-
+import math, random, os
 randomize()
 
-
-proc randomSalt*(): string =
-  ## Generate a random salt
-  ## Seconf priority salting
-
-  result = ""
-  for i in 0..127:
-    var r = rand(225)
-    if r >= 32 and r <= 126:
-      result.add(chr(rand(225)))
-
-
-proc devRandomSalt*(): string =
-  ## Generate random salt
-  ## First priority salting
-
-  when defined(posix):
-    result = ""
-    var f = open("/dev/urandom")
-    var randomBytes: array[0..127, char]
-    discard f.readBuffer(addr(randomBytes), 128)
-    for i in 0..127:
-      if ord(randomBytes[i]) >= 32 and ord(randomBytes[i]) <= 126:
-        result.add(randomBytes[i])
-    f.close()
-  else:
-    result = randomSalt()
-
+var urandom: File
+let useUrandom = urandom.open("/dev/urandom")
 
 proc makeSalt*(): string =
-  ## Creates a salt using a cryptographically secure random number generator.
-  ##
-  ## Ensures that the resulting salt contains no ``\0``.
-
-  try:
-    result = devRandomSalt()
-  except IOError:
-    result = randomSalt()
-
-  var newResult = ""
-  for i in 0..<result.len:
-    if result[i] != '\0':
-      newResult.add result[i]
-  return newResult
+  ## Generate random salt. Uses cryptographically secure /dev/urandom
+  ## on platforms where it is available, and Nim's random module in other cases.
+  result = ""
+  if not useUrandom:
+    var randomBytes: array[0..127, char]
+    discard urandom.readBuffer(addr(randomBytes), 128)
+    for ch in randomBytes:
+      if ord(ch) in {32..126}:
+        result.add(ch)
+  else:
+    for i in 0..127:
+      result.add(chr(rand(94) + 32)) # Generate numbers from 32 to 94 + 32 = 126


### PR DESCRIPTION
I didn't really test this one (I only tested it as a separate module).
Instead of checking for posix I just try to open "/dev/urandom", and if it doesn't exist - useUrandom will be false.
Also I've simplified checks for keeping only ASCII-printable characters in salt