### PR TITLE
Remove prism as standard and insert info text

### DIFF
--- a/nimwcpkg/tmpl/utils.tmpl
+++ b/nimwcpkg/tmpl/utils.tmpl
@@ -288,6 +288,52 @@
 
 </div>
 
+<hr>
+
+<h4 class="has-text-centered">Highlight code snippets</h4>
+<div>
+
+  <div class="field">
+    <div class="control">
+      <label class="label">Format code snippet</label>
+      <pre>&lt;pre>
+  &lt;code class="line-numbers language-nim">
+    proc nimProc() =
+      echo "Hello World"
+  &lt;/code>
+&lt;/pre></pre>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <label class="label">Import the syntax files you need (examples below)</label>
+      <pre>&lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism.min.css">
+&lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.css">
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/prism.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-nim.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-markup.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-css.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-javascript.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-python.min.js">&lt;/script>
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-bash.min.js">&lt;/script></pre>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <label class="label">Highlight code snippets</label>
+      <pre>&lt;script>
+  window.onload = function(){
+    Prism.highlightAll(false, function (){});
+  }
+&lt;/script></pre>
+    </div>
+  </div>
+
+</div>
+
 # if edit:
 <hr>
 <h4 class="has-text-centered">Delete page</h4>

--- a/public/js/editors.js
+++ b/public/js/editors.js
@@ -268,6 +268,8 @@ $(function() {
       lineWrapping: true,
       mode: "htmlmixed",
       autoCloseTags: true,
+      tabSize: 2,
+      indentWithTabs: false,
       matchTags: {bothTags: true},
       extraKeys: {"Ctrl-J": "toMatchingTag"}
     });
@@ -286,7 +288,6 @@ $(function() {
       editor.autoFormatRange(range.from, range.to);
       $("#save").attr("data-ischanged", "0");
     }
-    autoFormatSelection();
   }
 
 

--- a/public/js/js.js
+++ b/public/js/js.js
@@ -50,59 +50,6 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
 
 
 /*
-  Load JS and CSS files dynamic
-*/
-// Load JS
-function loadScript(content) {
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = content;
-  script.defer = true;
-  script.setAttribute("data-manual", "true");
-  document.body.appendChild(script);
-}
-// Load CSS style
-function loadStyle(content) {
-  var fileref = document.createElement("link");
-  fileref.rel = "stylesheet";
-  fileref.type = "text/css";
-  fileref.href = content;
-  document.getElementsByTagName("head")[0].appendChild(fileref)
-}
-window.onload = function(){
-  const $prism = document.querySelector(".prismOn");
-  if ($prism != null) {
-    loadStyle("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism.min.css")
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/prism.min.js")
-    loadStyle("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.css")
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.js")
-  }
-  if (document.querySelector(".prismOn.language-nim") != null) {
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-nim.min.js")
-  }
-  if (document.querySelector(".prismOn.language-css") != null) {
-	loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-css.min.js")
-  }
-  if (document.querySelector(".prismOn.language-javascript") != null) {
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-javascript.min.js")
-  }
-  if (document.querySelector(".prismOn.language-python") != null) {
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-python.min.js")
-  }
-  if (document.querySelector(".prismOn.language-bash") != null) {
-    loadScript("https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-bash.min.js")
-  }
-  if ($prism != null) {
-    setTimeout(function(){
-      Prism.highlightAll(false, function () {
-        console.log('Syntax highlight completed');
-      });
-    }, 1000);
-  }
-}
-
-
-/*
   Animations
 */
 var animation_elements = document.querySelectorAll('.reveal');


### PR DESCRIPTION
Prism (code syntax highlighter) was initialized by JS. If `.prismOn` class was present, it would append CSS and JS files to HEAD and FOOTER for loading, after that the highlighter was called.

This solution was prone for error due to the order of download CSS and JSS and running the highlighter. Furtermore the prism function was called on every pageload to check for `.prismOn`.

New solution removes prism from core JS. An info text is now available, which should help the user on how to insert highlightet code snippers.

I have also removed auto indentation from codemirror (raw html editor), because it was making wrong indentation of code snippets.