### PR TITLE
Redirect with Delay

### DIFF
--- a/nimwcpkg/nimwc_main.nim
+++ b/nimwcpkg/nimwc_main.nim
@@ -539,6 +539,7 @@ include "tmpl/sitemap.tmpl"
 include "tmpl/logs.tmpl"
 include "tmpl/serverinfo.tmpl"
 include "tmpl/editconfig.tmpl"
+include "tmpl/delayredirect.tmpl"
 when defined(firejail): include "tmpl/firejail.tmpl"
 
 

--- a/nimwcpkg/tmpl/delayredirect.tmpl
+++ b/nimwcpkg/tmpl/delayredirect.tmpl
@@ -1,0 +1,14 @@
+#? stdtmpl | standard
+#
+#proc genDelayRedirect*(url: string, message="**Wait!** ⏰", delaySeconds: byte = 5): string =
+#  result = ""
+<meta http-equiv="refresh" content="$delaySeconds; url=$url"/>
+<br>
+<div class="has-background-white has-text-black is-fullwidth" style="padding:9px;border: 1px solid grey;border-radius:4px">
+  <h1 class="has-text-centered has-text-weight-bold is-size-1"> Loading... </h1>
+  <progress class="progress is-large is-success is-fullwidth is-shadowless is-unselectable is-marginless" title="$delaySeconds Seconds"> Redirecting to $url on $delaySeconds Seconds </progress>
+  <hr>
+  <center class="is-unselectable">
+    ${ rst2html(message.strip) } <br>
+  </center>
+</div>


### PR DESCRIPTION
![nmwc-delayredirect](https://user-images.githubusercontent.com/1189414/54493365-eb8ded80-48ad-11e9-9c1d-e46eb312385e.png)

- Add 1 Template with a Redirect with a Delay page that also shows a Result text, for plugin developers and better UX than a vanilla redirect.
- You can pass a `delaySeconds` from `0` to `255` with a message for the user, if things going Ok or not or whats happening.
- Page is kinda Generic enought to be used everywhere, and the message should provide better UX than just `redirect "/"` when successful.
- This is useful for Plugins developers, but also on `/settings` we can improve the UX, on some places we are using just `redirect "/"` when successful.
- Default delay is `5` Seconds, so the user can see the Results message, our Backend is fast to do most things on less than 5 Seconds anyway.

**Before:**
```nim
get "/someurl":
  createTFD()
  if sucessful:
    redirect "/settings"

get "/reallySlowOperation":
  createTFD()
  if sucessful:
    redirect "/"

```

**After:**
```nim
get "/someurl":
  createTFD()
  if sucessful:
    resp genMain(c, genDelayRedirect("/settings", "**Nim world domination succesfull:** Returning to Settings page."))

get "/reallySlowOperation":
  createTFD()
  if sucessful:
    resp genMain(c, genDelayRedirect("/", "**Please Wait:** *Solving the squaring of the circle.*", 30))  # We know operation takes less than 30 seconds to complete.

```

**Code to Test it, add on `routes.nim`:**
```nim
  get "/delayredirect":
    createTFD()
    resp genMain(c, genDelayRedirect("/settings", message="**Your Message** *here*", 2))
```

Easy to Merge, since not touching any pre-existent code. :slightly_smiling_face: 
