### PR TITLE
Add HTML5 Notifications

### DIFF
--- a/nimwcpkg/nimwc_main.nim
+++ b/nimwcpkg/nimwc_main.nim
@@ -394,6 +394,10 @@ template createTFD() =
 #
 
 
+template notifyHtml*(message: string, title="NimWC 👑", iconUrl="/favicon.ico", timeout: byte = 3): string =
+  "Notification.requestPermission(()=>{const n=new Notification('" & title & "',{body:'" & message.strip & "',icon:'" & iconUrl & "'});setTimeout(()=>{n.close()}," & $timeout & "000)});"
+
+
 template minifyHtml*(htmlstr: string): string =
   when defined(release): replace(htmlstr, re">\s+<", "> <").strip else: htmlstr
 


### PR DESCRIPTION
![nimwc-notifications](https://user-images.githubusercontent.com/1189414/54497190-708cfd00-48d6-11e9-9812-7ac7542c294e.png)

- Add HTML5 Notifications.
- Working on Chromium & Firefox, mobile too ([74.5% browsers can use](https://caniuse.com/#search=notifications))
- 1 line template.
- This completes the user experience with https://github.com/ThomasTJdev/nim_websitecreator/pull/78#issue-261848574
- Auto-close with a timeout (since bubble is tiny, the message should be short, so I am defaulting it to 3 Seconds, but feel free to suggest other default, the user can pass its own anyways)

**Use:**
```html
<button onClick="${ notifyHtml("HTML5 Notifications!") }">Notification</button>

<a onClick="${ notifyHtml("HTML5 Notifications!") }">Notification</a>
```
:cat: 
