### PR TITLE
Remove symlink for storagepath

### DIFF
--- a/config/config_default.cfg
+++ b/config/config_default.cfg
@@ -8,8 +8,8 @@ port = 5432
 
 [Storage]
 storagedev = "fileslocal"  # Relative path within the app dir. Recommended to use "fileslocal"
-storage = "fileslocal"     # Full path needed and folder needs to exist, e.g. /mnt/efs/nimwc,
-                           # using "fileslocal" overrides to use "dev" options
+storage = ""               # Full path needed, e.g. /mnt/efs/nimwc,
+                           # using "fileslocal" or empty overrides to use "dev" options
 
 [Logging]
 logfiledev = "log/debug.log"

--- a/nimwcpkg/resources/files/files_efs.nim
+++ b/nimwcpkg/resources/files/files_efs.nim
@@ -3,36 +3,38 @@ import parsecfg, os, strutils, logging, ../utils/logging_nimwc
 
 setCurrentDir(getAppDir().replace("/nimwcpkg", ""))
 
-const
-  section = when defined(dev): "storagedev" else: "storage"
-  storageEFS* = "files/efs"
+const section = when defined(dev): "storagedev" else: "storage"
 
-let
-  appDir = replace(getAppDir(), "/nimwcpkg", "")
-  dict = loadConfig("config/config.cfg")
-  tempDir = dict.getSectionValue("Storage", section)
-  paths2create = [
-    "files", "files/efs", "fileslocal", tempDir & "/tmp",
-    tempDir & "/files", tempDir & "/files/private",
-    tempDir & "/files/public", tempDir & "/users",
+var storageEFS*: string
+
+
+proc setFolderPath(): string =
+  ## Sets the global folder path
+  let dict = loadConfig("config/config.cfg")
+  result = dict.getSectionValue("Storage", section)
+
+  if result == "fileslocal" or result == "":
+    result = replace(getAppDir(), "/nimwcpkg", "") / result
+
+  info("Storage path set to: " & result)
+  return result
+
+
+proc createFolders() =
+  ## Create folders
+  info("Checking that required folders exists.")
+  let paths2create = [
+    storageEFS,
+    storageEFS & "/tmp",
+    storageEFS & "/files",
+    storageEFS & "/files/private",
+    storageEFS & "/files/public",
+    storageEFS & "/users"
   ]
+  for folder in paths2create:
+    discard existsOrCreateDir(folder)
+    assert fpUserWrite in getFilePermissions(folder), "Wrong folder permissions:\n" & $getFilePermissions(folder) & folder
 
-# Create folders
-info("Checking that required 'files' folders exists.")
-for folder in paths2create:
-  discard existsOrCreateDir(folder)
-  assert fpUserWrite in getFilePermissions(folder), "Wrong folder permissions:\n" & $getFilePermissions(folder) & folder
 
-# Storage settings
-if tempDir == "fileslocal" or defined(dev):
-  info("Symlinking " & tempDir & " to files/efs")
-  try:
-    createSymlink(src= appDir & "/" & tempDir & "/*",
-                  dest=appDir & "/files/efs/")
-  except: discard
-else:
-  info("Symlinking " & tempDir & " to files/efs")
-  try:
-    createSymlink(src= tempDir & "/*",
-                  dest=appDir & "/files/efs/")
-  except: discard
+storageEFS = setFolderPath()
+createFolders()

--- a/nimwcpkg/resources/files/files_utils.nim
+++ b/nimwcpkg/resources/files/files_utils.nim
@@ -1,8 +1,10 @@
 import os
 
-const
-  filesListPrivatePath = "files/efs/files/private/*.*"
-  filesListPublicPath  = "files/efs/files/public/*.*"
+import files_efs
+
+let
+  filesListPrivatePath = storageEFS / "files/private/*.*"
+  filesListPublicPath  = storageEFS / "files/public/*.*"
 
 
 proc filesListPrivate*(): seq[string] {.inline.} =

--- a/nimwcpkg/resources/web/routes.nim
+++ b/nimwcpkg/resources/web/routes.nim
@@ -544,7 +544,7 @@ routes:
     if @"access" notin ["private", "public", "publicimage"]:
       resp("Error: Missing access right")
 
-    const
+    let
       efspublic = storageEFS & "/files/public/"
       efsprivate = storageEFS & "/files/private/"
     var
@@ -789,7 +789,7 @@ routes:
     ## Get a file
     createTFD()
     let filename = decodeUrl(@"filename")
-    var filepath = storageEFS & "/users/" & filename
+    let filepath = storageEFS & "/users/" & filename
     if not fileExists(filepath): resp("")
     sendFile(filepath)
 


### PR DESCRIPTION
Fix #94 

Remove symlinking in `files_efs.nim` and uses full path.