### PR TITLE
Let user decide to use lower or capital letter for tags

### DIFF
--- a/nimwcpkg/tmpl/utils.tmpl
+++ b/nimwcpkg/tmpl/utils.tmpl
@@ -212,7 +212,7 @@
   <div class="field">
     <div class="control">
       <label class="label">Tags</label>
-      <input class="input" type="text" name="tags" value="${tags}" placeholder="Comma separated tags, e.g. nim,macro" dir="auto" pattern="^[\p{ASCII}]{2,99}$$" onblur="this.value=this.value.replace(/\s\s+/g, ' ').replace(/^\s+|\s+$$/g, '').toLowerCase()">
+      <input class="input" type="text" name="tags" value="${tags}" placeholder="Comma separated tags, e.g. nim,macro" dir="auto" pattern="^[\p{ASCII}]{2,99}$$" onblur="this.value=this.value.replace(/\s\s+/g, ' ').replace(/^\s+|\s+$$/g, '')">
     </div>
   </div>
 


### PR DESCRIPTION
Removed `.toLowerCase()` from inline JS on tags. I have tags such as `NimWC` on my blog - I don't like NimWC to decide that is should be `nimwc`.

Ok?