### PR TITLE
Quit if user has provided arguments

### DIFF
--- a/nimwc.nim
+++ b/nimwc.nim
@@ -202,17 +202,23 @@ proc launcherActivated() =
   nimhaMain = startProcess(nimwcCommand, options = processOpts)
 
   while runInLoop:
+    # If nimha_main has been recompile, check for a new version
     if fileExists(appPath & "_new"):
       kill(nimhaMain)
       moveFile(appPath & "_new", appPath)
 
+    # Loop to check if nimwc_main is running
     if not running(nimhaMain):
+      # Quit if user has provided arguments
+      if args.len() != 0:
+        styledEcho(fgYellow, bgBlack, $now() & ": User provided arguments: " & args)
+        styledEcho(fgYellow, bgBlack, $now() & ": Run again without arguments, exiting..")
+        quit()
+
       styledEcho(fgYellow, bgBlack, $now() & ": Restarting in 1 second.")
       sleep(1000)
 
-      if userArgsRun != "":
-        styledEcho(fgGreen, bgBlack, " Using args: " & userArgsRun)
-
+      # Start nimha_main as process
       nimhaMain = startProcess(nimwcCommand, options = processOpts)
 
     sleep(2000)

--- a/nimwcpkg/nimwc_main.nim
+++ b/nimwcpkg/nimwc_main.nim
@@ -430,10 +430,6 @@ when isMainModule:
   assert db is DbConn, "Connection to DB could not be established, failed to open Database."
   info("Connection to DB is established.")
 
-  # Add admin user
-  if "newuser" in commandLineParams():
-    createAdminUser(db, commandLineParams())
-
   # When Demo Mode, Reset everything at start, create Test User, create Test Data, for use with Firejail `timeout=1`
   when defined(demo):
     {. hint: "Demo is Enabled, Database Resets Automatically every hour." .}
@@ -444,8 +440,9 @@ when isMainModule:
     # doAssert dict.getSectionValue("firejail", "timeout") == "1", "Firejail Timeout must be 1"
     info("Demo Mode: Database reset successful")
 
-  # Activate Google reCAPTCHA
-  setupReCapthca()
+  # Add admin user
+  if "newuser" in commandLineParams():
+    createAdminUser(db, commandLineParams())
 
   # Update sql database from extensions
   extensionUpdateDB(db)
@@ -462,15 +459,23 @@ when isMainModule:
       else:
         createStandardData(db, "bulma")
 
+  # If user has provided arguments then quit
+  if commandLineParams().len != 0:
+    quit()
+
   # Create robots.txt
   writeFile("public/robots.txt", "User-agent: *\nSitemap: " & mainWebsite & "/sitemap.xml")
+
+  # Activate Google reCAPTCHA
+  setupReCapthca()
 
   # Check if custom js and css exists
   if not fileExists("public/css/style_custom.css"):
     writeFile("public/css/style_custom.css", "")
   if not fileExists("public/js/js_custom.js"):
     writeFile("public/js/js_custom.js", "")
-  info("Up and running!.")
+
+  info("Up and running!")
 
 
 #

--- a/nimwcpkg/tmpl/user.tmpl
+++ b/nimwcpkg/tmpl/user.tmpl
@@ -292,7 +292,7 @@
             # when defined(demo) or defined(dev):
               minlength="4"
             # else:
-              minlength="10"
+              minlength="9"
             # end when
             >
           </div>


### PR DESCRIPTION
When the user provides arguments, perform arg-action and then quit(). Arg-actions should only be performed once.

Reason:
1. When enabling plugins and args are present, restarting nimwc will try to perform the arg-actions again.
2. When running in production and args are present, a restart/breakdown will try to perform the arg-actions again.

