### PR TITLE
--backupdb changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vscode
 
+backup
+
 config/config.cfg
 
 data/*

--- a/README.md
+++ b/README.md
@@ -198,14 +198,19 @@ curl https://raw.githubusercontent.com/ThomasTJdev/nim_websitecreator/master/dev
 
 These arguments should be prepended to executable file, e.g. `./nimwc cdata`
 
+* `--showconfig` = Show parsed INI configuration and compile options.
 * `--newadmin` = Add the Admin user.
-* `--insertdata` = Insert standard data (this will override existing data)
+* `--gitupdate` = Updates and force a hard reset.
+* `--initplugin` = Create plugin skeleton inside tmp/.
+* `--vacuumdb` = Vacuum database and continue (database maintenance).
+* `--backupdb` = Compressed full backup of database.
+* `--backupdb-gpg` = Compressed signed full backup of database.
+* `--newdb` = Generates the database with standard tables (does **not** override or delete tables). `newdb` will be initialized automatic, if no database exists.
+* `--insertdata` = Insert standard data, e.g `--insertdata bulma` (this will override existing data)
   * `bulma` = Use Bulma CSS
   * `bootstrap` = Use Bootstrap and jQuery
   * `clean` = No framework is used
-* `--newdb` = Generates the database with standard tables (does **not** override or delete tables). `newdb` will be initialized automatic, if no database exists.
-* `--gitupdate` = Updates and force a hard reset
-* `--initplugin` = Create plugin skeleton inside tmp/
+
 
 ## Compile options:
 

--- a/nimwc.nim
+++ b/nimwc.nim
@@ -104,7 +104,7 @@ const
     when defined(useStdoutAsStdmsg): " -d:useStdoutAsStdmsg", # Use Std Out as Std Msg
     when defined(nimOldShiftRight):  " -d:nimOldShiftRight",  # http://forum.nim-lang.org/t/4891#30600
     when defined(nimOldCaseObjects): " -d:nimOldCaseObjects", # old case switch
-    when defined(nimBinaryStdFiles): " -d:nimBinaryStdFiles", # stdin/stdout old binary open
+    when defined(nimBinaryStdFiles): " -d:d:nimBinaryStdFiles", # stdin/stdout old binary open
   ].join  ## Checking for known compile options and returning them as a space separated string at Compile-Time. See README.md for explanation of the options.
 
   nimwc_version =
@@ -179,13 +179,11 @@ proc updateNimwc() =
     pluginImport = readFile"plugins/plugin_import.txt"  # Save contents
     styleCustom = readFile"public/css/style_custom.css"
     jsCustom = readFile"public/js/js_custom.js"
-    humansTxt = readFile"public/humans.txt"
   when not defined(release): echo cmd
   discard execCmd(cmd)
   writeFile("plugins/plugin_import.txt", pluginImport)  # Write contents back
   writeFile("public/css/style_custom.css", styleCustom)
   writeFile("public/js/js_custom.js", jsCustom)
-  writeFile("public/humans.txt", humansTxt)
   echo "\n\n\nTo finish the update:\n - Compile NimWC\n - Run with the arg `--newdb`\n"
   quit("Git fetch done\n", 0)
 
@@ -391,7 +389,8 @@ when isMainModule:
         if not styleExist:
           echo("\nStandard data: Please specify data style:\n  1) bulma\n  2) bootstrap\n  3) clean\n!! Data not inserted !!")
       of "vacuumdb": echo vacuumDb(db)
-      of "backupdb": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"))
+      of "backupdb-gpg": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"), gpg=true)
+      of "backupdb": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"), gpg=false)
     of cmdArgument:
       discard
     of cmdEnd: quit("Wrong Arguments, please see Help with: --help", 1)

--- a/nimwc.nim
+++ b/nimwc.nim
@@ -130,17 +130,18 @@ Options:
  -h --help        Show this help.
  --version        Show Version and exit.
  -f, --forcebuild Force Recompile.
- --showconfig     Show parsed INI configuration and compile options and continue
- --newadmin       Add 1 new Admin or Moderator user (asks name, mail & password)
- --gitupdate      Update from Git origin master then force a hard reset and exit
+ --showconfig     Show parsed INI configuration and compile options.
+ --newadmin       Add 1 new Admin or Moderator user (asks name, mail & password).
+ --gitupdate      Update from Git origin master then force a hard reset and exit.
  --initplugin     Create 1 new empty plugin skeleton inside the folder ./tmp/
  --vacuumdb       Vacuum database and continue (database maintenance).
- --backupdb       Compressed signed full backup of database and continue.
- --newdb          Generates a database with standard tables (Wont override data)
-                  If no database exists, new db will be initialized automatically
- --insertdata:bulma     Insert Bulma standard data into the database (default, overrides data)
- --insertdata:bootstrap Insert Bootstrap standard data into the database (overrides data)
- --insertdata:clean     Insert clean (no framework) standard data into the database (overrides data)
+ --backupdb       Compressed full backup of database.
+ --backupdb-gpg   Compressed signed full backup of database.
+ --newdb          Generates a database with standard tables (Wont override data).
+                  If no database exists, new db will be initialized automatically.
+ --insertdata bulma     Insert Bulma standard data into the database (default, overrides data)
+ --insertdata bootstrap Insert Bootstrap standard data into the database (overrides data)
+ --insertdata clean     Insert clean (no framework) standard data into the database (overrides data)
 
 Compile options (features when compiling source code):
  -d:postgres      Postgres database is enabled (SQLite is default)

--- a/nimwc.nim
+++ b/nimwc.nim
@@ -392,8 +392,8 @@ when isMainModule:
         if not styleExist:
           echo("\nStandard data: Please specify data style:\n  1) bulma\n  2) bootstrap\n  3) clean\n!! Data not inserted !!")
       of "vacuumdb": echo vacuumDb(db)
-      of "backupdb-gpg": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"), gpg=true)
-      of "backupdb": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"), gpg=false)
+      of "backupdb-gpg": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"))
+      of "backupdb": echo backupDb(cfg.getSectionValue("Database", when defined(postgres): "name" else: "host"), checksum=false, sign=false, targz=false)
     of cmdArgument:
       discard
     of cmdEnd: quit("Wrong Arguments, please see Help with: --help", 1)

--- a/nimwc.nim
+++ b/nimwc.nim
@@ -104,7 +104,7 @@ const
     when defined(useStdoutAsStdmsg): " -d:useStdoutAsStdmsg", # Use Std Out as Std Msg
     when defined(nimOldShiftRight):  " -d:nimOldShiftRight",  # http://forum.nim-lang.org/t/4891#30600
     when defined(nimOldCaseObjects): " -d:nimOldCaseObjects", # old case switch
-    when defined(nimBinaryStdFiles): " -d:d:nimBinaryStdFiles", # stdin/stdout old binary open
+    when defined(nimBinaryStdFiles): " -d:nimBinaryStdFiles", # stdin/stdout old binary open
   ].join  ## Checking for known compile options and returning them as a space separated string at Compile-Time. See README.md for explanation of the options.
 
   nimwc_version =
@@ -180,11 +180,13 @@ proc updateNimwc() =
     pluginImport = readFile"plugins/plugin_import.txt"  # Save contents
     styleCustom = readFile"public/css/style_custom.css"
     jsCustom = readFile"public/js/js_custom.js"
+    humansTxt = readFile"public/humans.txt"
   when not defined(release): echo cmd
   discard execCmd(cmd)
   writeFile("plugins/plugin_import.txt", pluginImport)  # Write contents back
   writeFile("public/css/style_custom.css", styleCustom)
   writeFile("public/js/js_custom.js", jsCustom)
+  writeFile("public/humans.txt", humansTxt)
   echo "\n\n\nTo finish the update:\n - Compile NimWC\n - Run with the arg `--newdb`\n"
   quit("Git fetch done\n", 0)
 

--- a/nimwcpkg/resources/administration/createdb.nim
+++ b/nimwcpkg/resources/administration/createdb.nim
@@ -198,36 +198,50 @@ proc generateDB*(db: DbConn) =
 
 
 proc backupDb*(dbname: string,
-    filename = fileBackup & replace($now(), ":", "_") & ".sql",
+    filename = "backup" / fileBackup & replace($now(), ":", "_") & ".sql",
     host = "localhost", port = Port(5432), username = getEnv("USER", "root"),
     dataOnly = false, inserts = false, checksum = true, sign = true, targz = true,
-    ): tuple[output: TaintedString, exitCode: int] =
+    gpg = false): tuple[output: TaintedString, exitCode: int] =
   ## Backup the whole Database to a plain-text Raw SQL Query human-readable file.
   preconditions(dbname.len > 0, host.len > 0, username.len > 0,
-    when defined(postgres): findExe"pg_dump".len > 0 else: findExe"sqlite3".len > 0)
+    when defined(postgres): findExe("pg_dump").len > 0 else: findExe("sqlite3").len > 0)
+
+  discard existsOrCreateDir(nimwcpkgDir / "backup")
+
   when defined(postgres):
     var cmd = cmdBackup.format(host, $port, username, filename, dbname,
     (if dataOnly: " --data-only " else: "") & (if inserts: " --inserts " else: ""))
-  else:  # SQLite .dump is Not working, Docs says it should.
+  else:  # TODO: SQLite .dump is Not working, Docs says it should.
     var cmd = cmdBackup.format(dbname, filename)
-  when not defined(release): echo cmd
+
+  when not defined(release): info("Database backup: " & cmd)
   result = execCmdEx(cmd)
-  if checksum and result.exitCode == 0 and findExe"sha512sum".len > 0:
+
+  if gpg and checksum and result.exitCode == 0 and findExe("sha512sum").len > 0:
     cmd = cmdChecksum & filename & " > " & filename & ".sha512"
-    when not defined(release): echo cmd
+    when not defined(release): info("Database backup (sha512sum): " & cmd)
     result = execCmdEx(cmd)
-    if sign and result.exitCode == 0 and findExe"gpg".len > 0:
+
+    if sign and result.exitCode == 0 and findExe("gpg").len > 0:
       cmd = cmdSign & filename
-      when not defined(release): echo cmd
+      when not defined(release): info("Database backup (gpg): " & cmd)
       result = execCmdEx(cmd)
-      if targz and result.exitCode == 0 and findExe"tar".len > 0:
+
+      if targz and result.exitCode == 0 and findExe("tar").len > 0:
         cmd = cmdTar & filename & ".tar.gz " & filename & " " & filename & ".sha512 " & filename & ".asc"
-        when not defined(release): echo cmd
+
+        when not defined(release): info("Database backup (tar): " & cmd)
         result = execCmdEx(cmd)
+
         if result.exitCode == 0:
           removeFile(filename)
           removeFile(filename & ".sha512")
           removeFile(filename & ".asc")
+
+  if result.exitCode == 0:
+    info("Database backup: Done - " & filename)
+  else:
+    info("Database backup: Fail - " & filename)
 
 
 proc vacuumDb*(db: DbConn): bool {.inline.} =

--- a/nimwcpkg/resources/administration/createdb.nim
+++ b/nimwcpkg/resources/administration/createdb.nim
@@ -200,8 +200,7 @@ proc generateDB*(db: DbConn) =
 proc backupDb*(dbname: string,
     filename = "backup" / fileBackup & replace($now(), ":", "_") & ".sql",
     host = "localhost", port = Port(5432), username = getEnv("USER", "root"),
-    dataOnly = false, inserts = false, checksum = true, sign = true, targz = true,
-    gpg = false): tuple[output: TaintedString, exitCode: int] =
+    dataOnly = false, inserts = false, checksum = true, sign = true, targz = true): tuple[output: TaintedString, exitCode: int] =
   ## Backup the whole Database to a plain-text Raw SQL Query human-readable file.
   preconditions(dbname.len > 0, host.len > 0, username.len > 0,
     when defined(postgres): findExe("pg_dump").len > 0 else: findExe("sqlite3").len > 0)
@@ -217,7 +216,7 @@ proc backupDb*(dbname: string,
   when not defined(release): info("Database backup: " & cmd)
   result = execCmdEx(cmd)
 
-  if gpg and checksum and result.exitCode == 0 and findExe("sha512sum").len > 0:
+  if checksum and result.exitCode == 0 and findExe("sha512sum").len > 0:
     cmd = cmdChecksum & filename & " > " & filename & ".sha512"
     when not defined(release): info("Database backup (sha512sum): " & cmd)
     result = execCmdEx(cmd)


### PR DESCRIPTION
Allow for backup db without gpg signing.

Create folder `backup` to store backups in.

Use `info()` on messages.