### PR TITLE
Updated db_connector and otp package changes.

### DIFF
--- a/nimwc.nim
+++ b/nimwc.nim
@@ -4,8 +4,8 @@ import
   nimwcpkg/constants/constants, nimwcpkg/enums/enums,
   nimwcpkg/databases/databases, nimwcpkg/files/files, nimwcpkg/utils/loggers
 
-when defined(postgres): import db_postgres
-else:                   import db_sqlite
+when defined(postgres): import db_connector/db_postgres
+else:                   import db_connector/db_sqlite
 
 when defined(firejail): from firejail import firejailVersion, firejailFeatures
 

--- a/nimwc.nim
+++ b/nimwc.nim
@@ -4,8 +4,12 @@ import
   nimwcpkg/constants/constants, nimwcpkg/enums/enums,
   nimwcpkg/databases/databases, nimwcpkg/files/files, nimwcpkg/utils/loggers
 
-when defined(postgres): import db_connector/db_postgres
-else:                   import db_connector/db_sqlite
+when NimMajor < 2:
+    when defined(postgres): import db_postgres
+    else:                   import db_sqlite
+else:
+    when defined(postgres): import db_connector/db_postgres
+    else:                   import db_connector/db_sqlite
 
 when defined(firejail): from firejail import firejailVersion, firejailFeatures
 

--- a/nimwcpkg/constants/_sqls.nim
+++ b/nimwcpkg/constants/_sqls.nim
@@ -1,8 +1,11 @@
 ## Static Postgres/SQLite string constants, do NOT put any run-time logic here, only consts.
 ## Do NOT import this file directly, instead import ``constants.nim``
 from strutils import format
-from db_connector/db_common import sql
 
+when NimMajor < 2:
+    from db_common import sql
+else:
+    from db_connector/db_common import sql
 
 when defined(postgres):
   const

--- a/nimwcpkg/constants/_sqls.nim
+++ b/nimwcpkg/constants/_sqls.nim
@@ -1,7 +1,7 @@
 ## Static Postgres/SQLite string constants, do NOT put any run-time logic here, only consts.
 ## Do NOT import this file directly, instead import ``constants.nim``
 from strutils import format
-from db_common import sql
+from db_connector/db_common import sql
 
 
 when defined(postgres):

--- a/nimwcpkg/databases/databases.nim
+++ b/nimwcpkg/databases/databases.nim
@@ -3,8 +3,8 @@ import os, parsecfg, tables, osproc, logging, times, nativesockets, strutils, rd
 import ../constants/constants, ../utils/configs, ../passwords/passwords, ../enums/enums
 export head, navbar, footer, title  # HTML template fragments
 
-when defined(postgres): import db_postgres
-else:                   import db_sqlite
+when defined(postgres): import db_connector/db_postgres
+else:                   import db_connector/db_sqlite
 
 
 let nimwcpkgDir = getAppDir().replace("/nimwcpkg", "")

--- a/nimwcpkg/databases/databases.nim
+++ b/nimwcpkg/databases/databases.nim
@@ -3,9 +3,12 @@ import os, parsecfg, tables, osproc, logging, times, nativesockets, strutils, rd
 import ../constants/constants, ../utils/configs, ../passwords/passwords, ../enums/enums
 export head, navbar, footer, title  # HTML template fragments
 
-when defined(postgres): import db_connector/db_postgres
-else:                   import db_connector/db_sqlite
-
+when NimMajor < 2:
+    when defined(postgres): import db_postgres
+    else:                   import db_sqlite
+else:
+    when defined(postgres): import db_connector/db_postgres
+    else:                   import db_connector/db_sqlite
 
 let nimwcpkgDir = getAppDir().replace("/nimwcpkg", "")
 assert dirExists(nimwcpkgDir), "nimwcpkg directory not found"

--- a/nimwcpkg/nimwc_main.nim
+++ b/nimwcpkg/nimwc_main.nim
@@ -31,12 +31,12 @@ import
   constants/constants, enums/enums, databases/databases, emails/emails, files/files,
   passwords/passwords, sessions/sessions, utils/loggers, plugins/plugins, webs/html_utils
 
-
-when defined(postgres):
-  import db_connector/db_postgres
+when NimMajor < 2:
+    when defined(postgres): import db_postgres
+    else:                   import db_sqlite
 else:
-  import db_connector/db_sqlite
-
+    when defined(postgres): import db_connector/db_postgres
+    else:                   import db_connector/db_sqlite
 
 when defined(webp):
   from webp import cwebp

--- a/nimwcpkg/nimwc_main.nim
+++ b/nimwcpkg/nimwc_main.nim
@@ -33,9 +33,9 @@ import
 
 
 when defined(postgres):
-  import db_postgres
+  import db_connector/db_postgres
 else:
-  import db_sqlite
+  import db_connector/db_sqlite
 
 
 when defined(webp):
@@ -316,7 +316,7 @@ proc login(c: var TData, email, pass, totpRaw: string): tuple[isLoginOk: bool, s
         if totp in [000000, 111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999]:
           return (false, "2 Factor Authentication Number must not be 6 identical digits")
 
-        let totpServerSide = $newTotp(row[7]).now()
+        let totpServerSide = $(Totp.init(row[7]).now())
         when not defined(release):
           echo "TOTP SERVER: " & totpServerSide
           echo "TOTP USER  : " & $totp

--- a/nimwcpkg/webs/routes.nim
+++ b/nimwcpkg/webs/routes.nim
@@ -556,7 +556,7 @@ routes:
     restrictTestuser(HttpGet)
     if unlikely(not c.loggedIn): redirect("/")
     try:
-      if $newTotp(@"twofakey").now() == @"testcode":
+      if $(Totp.init(@"twofakey").now()) == @"testcode":
         resp("Success, the code matched")
       else:
         resp("Error, code did not match")


### PR DESCRIPTION
db_connector/ prefix should be use for (db_common, db_sqlite, db_postgres)
$newTotp... to be changed to $(Totp.init...